### PR TITLE
Improve package.json/types

### DIFF
--- a/dist/bundle.cjs.js
+++ b/dist/bundle.cjs.js
@@ -113,6 +113,7 @@ registerFunc('fac', (...args) => factorial(args[0]));
 registerFunc('max', (...args) => Math.max(...args));
 registerFunc('min', (...args) => Math.min(...args));
 
+exports.TokenType = void 0;
 (function (TokenType) {
     TokenType[TokenType["EOF"] = 0] = "EOF";
     TokenType[TokenType["ILLEGAL"] = 1] = "ILLEGAL";

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -1,0 +1,64 @@
+declare function compute(calcul: string): number;
+
+declare type Position = number;
+
+declare enum TokenType {
+    EOF = 0,
+    ILLEGAL = 1,
+    NUMBER = 2,
+    IDENT = 3,
+    OPERATOR = 4,
+    LPAREN = 5,
+    RPAREN = 6
+}
+interface Token {
+    type: TokenType;
+    start: Position;
+    end: Position;
+    value: string;
+}
+
+declare class Lexer {
+    private pos;
+    private readonly src;
+    private char;
+    result: Token[];
+    constructor(src: string);
+    private get nextChar();
+    private readChar;
+    static lex(src: string): Token[];
+    lex(): Token;
+    private lexIdent;
+    private lexNumber;
+}
+
+declare type Constant = number | number;
+declare const registerConstant: (name: string, value: number) => void;
+
+declare abstract class Operation {
+    abstract do(...args: number[]): number;
+}
+
+declare class Parser {
+    private readonly output;
+    private readonly operation;
+    private readonly src;
+    private token;
+    private pos;
+    constructor(tokens: Token[]);
+    get result(): Array<Constant | number | Operation>;
+    private get nextToken();
+    private get previousToken();
+    private readToken;
+    static parse(expr: string): Array<Constant | number | Operation>;
+    private parse;
+    private get lastOperation();
+    private parseOperator;
+    private parseRightParenthesis;
+}
+
+declare const registerOperator: (char: string, precedence: number, fn: (a: number, b: number) => number, leftAssociative?: boolean) => void;
+
+declare const registerFunc: (name: string, fn: (...args: number[]) => number) => void;
+
+export { Lexer, Parser, Token, TokenType, compute, registerConstant, registerFunc, registerOperator };

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,18 +23,22 @@
         "jest": "^26.6.3",
         "nyc": "^15.1.0",
         "rollup": "^2.36.1",
+        "rollup-plugin-dts": "^4.2.2",
         "ts-jest": "^26.4.4",
         "ts-node": "^9.1.1",
         "typescript": "^4.1.3"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.10.4"
+        "@babel/highlight": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
@@ -188,10 +192,13 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-      "dev": true
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@babel/helpers": {
       "version": "7.12.5",
@@ -205,14 +212,17 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
@@ -2386,7 +2396,7 @@
     "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
     "node_modules/combined-stream": {
@@ -2844,7 +2854,7 @@
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
@@ -4213,9 +4223,9 @@
       "dev": true
     },
     "node_modules/fsevents": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.1.tgz",
-      "integrity": "sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
@@ -4430,7 +4440,7 @@
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -7031,6 +7041,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.26.2",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.2.tgz",
+      "integrity": "sha512-NzzlXpclt5zAbmo6h6jNc8zl2gNRGHvmsZW4IvZhTC4W7k4OlLP+S5YLussa/r3ixNT66KOQfNORlXHSOy/X4A==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -8242,9 +8264,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.36.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.36.1.tgz",
-      "integrity": "sha512-eAfqho8dyzuVvrGqpR0ITgEdq0zG2QJeWYh+HeuTbpcaXk8vNFc48B7bJa1xYosTCKx0CuW+447oQOW8HgBIZQ==",
+      "version": "2.77.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.2.tgz",
+      "integrity": "sha512-m/4YzYgLcpMQbxX3NmAqDvwLATZzxt8bIegO78FZLl+lAgKJBd1DRAOeEiZcKOIOPjxE6ewHWHNgGEalFXuz1g==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -8253,22 +8275,29 @@
         "node": ">=10.0.0"
       },
       "optionalDependencies": {
-        "fsevents": "~2.1.2"
+        "fsevents": "~2.3.2"
       }
     },
-    "node_modules/rollup/node_modules/fsevents": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-      "deprecated": "\"Please update to latest v2.3 or v2.2\"",
+    "node_modules/rollup-plugin-dts": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-4.2.2.tgz",
+      "integrity": "sha512-A3g6Rogyko/PXeKoUlkjxkP++8UDVpgA7C+Tdl77Xj4fgEaIjPSnxRmR53EzvoYy97VMVwLAOcWJudaVAuxneQ==",
       "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
+      "dependencies": {
+        "magic-string": "^0.26.1"
+      },
       "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+        "node": ">=v12.22.11"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Swatinem"
+      },
+      "optionalDependencies": {
+        "@babel/code-frame": "^7.16.7"
+      },
+      "peerDependencies": {
+        "rollup": "^2.55",
+        "typescript": "^4.1"
       }
     },
     "node_modules/rsvp": {
@@ -8837,6 +8866,12 @@
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "deprecated": "See https://github.com/lydell/source-map-url#deprecated",
+      "dev": true
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
     },
     "node_modules/spawn-wrap": {
@@ -9922,12 +9957,12 @@
   },
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.10.4"
+        "@babel/highlight": "^7.18.6"
       }
     },
     "@babel/core": {
@@ -10073,9 +10108,9 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
       "dev": true
     },
     "@babel/helpers": {
@@ -10090,12 +10125,12 @@
       }
     },
     "@babel/highlight": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.10.4",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
@@ -11775,7 +11810,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
     "combined-stream": {
@@ -12138,7 +12173,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true
     },
     "escodegen": {
@@ -13167,9 +13202,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.1.tgz",
-      "integrity": "sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "optional": true
     },
@@ -13330,7 +13365,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true
     },
     "has-symbols": {
@@ -15286,6 +15321,15 @@
         "yallist": "^4.0.0"
       }
     },
+    "magic-string": {
+      "version": "0.26.2",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.2.tgz",
+      "integrity": "sha512-NzzlXpclt5zAbmo6h6jNc8zl2gNRGHvmsZW4IvZhTC4W7k4OlLP+S5YLussa/r3ixNT66KOQfNORlXHSOy/X4A==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -16197,21 +16241,22 @@
       }
     },
     "rollup": {
-      "version": "2.36.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.36.1.tgz",
-      "integrity": "sha512-eAfqho8dyzuVvrGqpR0ITgEdq0zG2QJeWYh+HeuTbpcaXk8vNFc48B7bJa1xYosTCKx0CuW+447oQOW8HgBIZQ==",
+      "version": "2.77.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.2.tgz",
+      "integrity": "sha512-m/4YzYgLcpMQbxX3NmAqDvwLATZzxt8bIegO78FZLl+lAgKJBd1DRAOeEiZcKOIOPjxE6ewHWHNgGEalFXuz1g==",
       "dev": true,
       "requires": {
-        "fsevents": "~2.1.2"
-      },
-      "dependencies": {
-        "fsevents": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-          "dev": true,
-          "optional": true
-        }
+        "fsevents": "~2.3.2"
+      }
+    },
+    "rollup-plugin-dts": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-4.2.2.tgz",
+      "integrity": "sha512-A3g6Rogyko/PXeKoUlkjxkP++8UDVpgA7C+Tdl77Xj4fgEaIjPSnxRmR53EzvoYy97VMVwLAOcWJudaVAuxneQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.16.7",
+        "magic-string": "^0.26.1"
       }
     },
     "rsvp": {
@@ -16675,6 +16720,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
     },
     "spawn-wrap": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "main": "dist/bundle.cjs.js",
   "module": "dist/bundle.es.js",
   "types": "dist/types.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "prepublish": "npm run build && npm run coverage",
     "lint": "eslint src tests",
@@ -17,6 +20,7 @@
   "keywords": [],
   "author": "Alexandre Negrel",
   "license": "MIT",
+  "repository": "github:negrel/mep",
   "devDependencies": {
     "@rbnlffl/rollup-plugin-eslint": "^1.1.4",
     "@rollup/plugin-typescript": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "MEP is a mathematical expression parser for JavaScript",
   "main": "dist/bundle.cjs.js",
   "module": "dist/bundle.es.js",
+  "types": "dist/types.d.ts",
   "scripts": {
     "prepublish": "npm run build && npm run coverage",
     "lint": "eslint src tests",
@@ -31,9 +32,9 @@
     "jest": "^26.6.3",
     "nyc": "^15.1.0",
     "rollup": "^2.36.1",
+    "rollup-plugin-dts": "^4.2.2",
     "ts-jest": "^26.4.4",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.3"
-  },
-  "dependencies": {}
+  }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,22 +1,34 @@
-import typescript from '@rollup/plugin-typescript'
 import eslint from '@rbnlffl/rollup-plugin-eslint'
+import typescript from '@rollup/plugin-typescript'
+import dts from 'rollup-plugin-dts'
 
 const watch = {
   include: 'src'
 }
 
-export default {
-  input: 'src/index.ts',
-  output: [
-    {
-      file: 'dist/bundle.cjs.js',
-      format: 'cjs'
-    },
-    {
-      file: 'dist/bundle.es.js',
+export default [
+  {
+    input: 'src/index.ts',
+    output: [
+      {
+        file: 'dist/bundle.cjs.js',
+        format: 'cjs'
+      },
+      {
+        file: 'dist/bundle.es.js',
+        format: 'es'
+      }
+    ],
+    watch,
+    plugins: [eslint(), typescript()]
+  },
+  {
+    input: 'src/index.ts',
+    output: {
+      file: 'dist/types.d.ts',
       format: 'es'
-    }
-  ],
-  watch,
-  plugins: [eslint(), typescript()]
-}
+    },
+    watch,
+    plugins: [dts()]
+  }
+]


### PR DESCRIPTION
Exports declarations so library-consumers can use the types
before:
![image](https://user-images.githubusercontent.com/55899582/181865894-b69113ea-0236-4def-9123-73c17636503f.png)
after:
![image](https://user-images.githubusercontent.com/55899582/181865960-85d06baa-9dc0-4447-be9c-0c900e1282b9.png)


Reduces the size by excluding files like src, test, config files etc. which is common practice
before:
```
package size:  10.0 kB                                 
unpacked size: 55.8 kB                                 
total files:   22      
```
after:
```
npm notice === Tarball Contents === 
npm notice 1.1kB  LICENSE           
npm notice 1.8kB  README.md         
npm notice 13.0kB dist/bundle.cjs.js
npm notice 12.6kB dist/bundle.es.js 
npm notice 1.6kB  dist/types.d.ts   
npm notice 1.3kB  package.json      
npm notice === Tarball Details === 
npm notice name:          mep                                     
npm notice version:       1.0.1                                   
npm notice filename:      mep-1.0.1.tgz                           
npm notice package size:  5.5 kB                                  
npm notice unpacked size: 31.4 kB                                 
npm notice shasum:        56daacc7bcf643b081a44e19ae9621b089ebadd5
npm notice integrity:     sha512-lbHovp3RbN1tk[...]pNd4S2rw2104Q==
npm notice total files:   6                
```